### PR TITLE
Jmaslak week 6, problem 2

### DIFF
--- a/challenge-006/joelle-maslak/perl5/ch-2.pl
+++ b/challenge-006/joelle-maslak/perl5/ch-2.pl
@@ -6,7 +6,7 @@ use warnings;
 use bignum;
 
 #
-# Copyright © 2019 Joelle Maslak
+# Copyright (C) 2019 Joelle Maslak
 # All Rights Reserved - See License
 #
 # I am assuming that we really wanted Ramanujan's Constant, and not the
@@ -16,5 +16,6 @@ use bignum;
 # Checked against http://oeis.org/A060295
 
 # We'll give *33* digits of precison, not 32.  ;)
+# Formula is from the Wiki page.  :)  It's accurate to 33 digits.
 say substr(640320**3 + 744 - 196844/(640320**3 + 744), 0, 34);
 

--- a/challenge-006/joelle-maslak/perl5/ch-2.pl
+++ b/challenge-006/joelle-maslak/perl5/ch-2.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+use v5.26;
+use strict;
+use warnings;
+
+use bignum;
+
+#
+# Copyright © 2019 Joelle Maslak
+# All Rights Reserved - See License
+#
+# I am assuming that we really wanted Ramanujan's Constant, and not the
+# linked to Wiki page on the Landau-Ramanujan Constant which is
+# something else entirely!
+#
+# Checked against http://oeis.org/A060295
+
+# We'll give *33* digits of precison, not 32.  ;)
+say substr(640320**3 + 744 - 196844/(640320**3 + 744), 0, 34);
+

--- a/challenge-006/joelle-maslak/perl6/ch-2.p6
+++ b/challenge-006/joelle-maslak/perl6/ch-2.p6
@@ -12,5 +12,6 @@ use v6;
 # Checked against http://oeis.org/A060295
 
 # We'll give *33* digits of precison, not 32.  ;)
+# Formula is from the Wiki page.  :)  It's accurate to 33 digits.
 say (640320³ + 744 - 196844.FatRat/(640320³ + 744)).Str.substr(0,34);
 

--- a/challenge-006/joelle-maslak/perl6/ch-2.p6
+++ b/challenge-006/joelle-maslak/perl6/ch-2.p6
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl6
+use v6;
+
+#
+# Copyright © 2019 Joelle Maslak
+# All Rights Reserved - See License
+#
+# I am assuming that we really wanted Ramanujan's Constant, and not the
+# linked to Wiki page on the Landau-Ramanujan Constant which is
+# something else entirely!
+#
+# Checked against http://oeis.org/A060295
+
+# We'll give *33* digits of precison, not 32.  ;)
+say (640320³ + 744 - 196844.FatRat/(640320³ + 744)).Str.substr(0,34);
+


### PR DESCRIPTION
Perl 5 & 6 solutions attached.

You linked to https://en.wikipedia.org/wiki/Landau%E2%80%93Ramanujan_constant which is the Landau-Ramanujan Constant.

That's not the same thing as the Ramanujan's Constant, which you can find here:
https://en.wikipedia.org/wiki/Heegner_number#Almost_integers_and_Ramanujan's_constant

Since the Ramanujan's constant is fairly easy to calculate to 33 digits of precision, I solved for that.  The Landau-Ramanujan Constant is not easy to calculate to 33 digits of precision!  Please let me know if I solved for the wrong constant.