### PR TITLE
Add missing 0 to word gap

### DIFF
--- a/challenge-035/roger-bell-west/perl5/ch-1.pl
+++ b/challenge-035/roger-bell-west/perl5/ch-1.pl
@@ -37,7 +37,7 @@ foreach my $word (split ' ',$m) {
   }
   push @l,join('000',@w);
 }
-print join('000000',@l),"\n";
+print join('0000000',@l),"\n";
 
 __DATA__
 E .

--- a/challenge-035/roger-bell-west/perl5/ch-2.pl
+++ b/challenge-035/roger-bell-west/perl5/ch-2.pl
@@ -26,7 +26,7 @@ while (<>) {
 my $m=join('',@in);
 
 my @m;
-foreach my $word (split /000000+/,$m) {
+foreach my $word (split /0000000+/,$m) {
   my @w;
   foreach my $char (split /000+/,$word) {
     push @w,($d{$char} or '?');

--- a/challenge-035/roger-bell-west/perl6/ch-1.p6
+++ b/challenge-035/roger-bell-west/perl6/ch-1.p6
@@ -67,4 +67,4 @@ for grep /./,split ' ',$m -> $word {
   }
   push @l,join('000',@w);
 }
-print join('000000',@l),"\n";
+print join('0000000',@l),"\n";

--- a/challenge-035/roger-bell-west/perl6/ch-2.p6
+++ b/challenge-035/roger-bell-west/perl6/ch-2.p6
@@ -56,7 +56,7 @@ for lines() {
 my $m=join('',@in);
 
 my @m;
-for grep /./,split /000000+/,$m -> $word {
+for grep /./,split /0000000+/,$m -> $word {
   my @w;
   for grep /./,split /000+/,$word -> $char {
     push @w,(%d{$char} or '?');


### PR DESCRIPTION
If @Firedrake does not mind, I've proposed a change to update their solutions. I was using their script to test my own, and noticed it had 6 zeros for the word gap rather than 7.