### PR TITLE
Add .precomp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.precomp/


### PR DESCRIPTION
Ignore any .precomp directories created for Raku modules.