### PR TITLE
edges -> next (fix silly search/replace error)

### DIFF
--- a/challenge-053/ryan-thompson/perl/ch-2.pl
+++ b/challenge-053/ryan-thompson/perl/ch-2.pl
@@ -19,7 +19,7 @@ sub vowel_string {
 
     my @vstrs;
     while (my $str = shift @queue) {
-        push @vstrs, $str    and edges if $len <= length $str;
+        push @vstrs, $str    and next if $len <= length $str;
         push @queue, $str.$_ for @{$edges{ substr $str, -1 }}
     }
     @vstrs;


### PR DESCRIPTION
Found this during my review. When I was blogging, I wanted to rename a variable `%next` to `%edges`. Search/replace without testing was obviously not smart.