### PR TITLE
Add necessary check for required option -k

### DIFF
--- a/challenge-056/jaredor/perl/ch-1.pl
+++ b/challenge-056/jaredor/perl/ch-1.pl
@@ -14,6 +14,7 @@ GetOptions( 'k=i' => \$difference ) or die "Problem with GetOptions.";
 
 # "non negative integer k"
 
+die "The --k option must be used to set the difference." unless defined $difference;
 die "The --k option must be non-negative: $difference" unless $difference >= 0;
 
 # "array @N of positive integers (sorted)"


### PR DESCRIPTION
Thank you Mohammad, for catching the warning for null comparison against the user option for -k. I've implemented your suggestion, but I hope you don't mind that I recast it using my style: I like "die ... unless ..." for going through validation checks. Cheers, --Jared