### PR TITLE
ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .precomp/
 .DS_Store
 .vstags
+.*.swp


### PR DESCRIPTION
Would be nice to exclude .*.swp files.