### PR TITLE
Better messages on bad inputs

### DIFF
--- a/challenge-072/yary-h/range.raku
+++ b/challenge-072/yary-h/range.raku
@@ -8,11 +8,16 @@
 # Playing with command-line validation.
 # Lines are ints, end_line is greater than begin_line,
 # all input files are readable- OK to skip that, CatHandle would complain.
-sub MAIN(Int $line_to_start is copy,				#= First line to print
-         Int $end_line where * >= $line_to_start,	#= Last line to print
-         *@input_file where (*.all).IO.f #= File(s) to read from. Also reads STDIN.
-	) {
-	.say if --$line_to_start < 1
-		for IO::CatHandle.new(@input_file, $*IN).lines($end_line)
-	# Alternative would be to use .lines.kv to get line num with line
+sub MAIN(Int $line_to_start is copy,    #= First line to print
+         Int $end_line                  #= Last line to print
+            where { $_ >= $line_to_start
+                or die "end_line cannot be less than line_to_start" },
+
+         *@input_file       #= File(s) to read from. Also reads STDIN.
+            where { .all.IO.f
+                or die "Not a file path:\n  { .grep({! .IO.f}).join: "\n  " } "}
+    ) {
+    .say if --$line_to_start < 1
+        for IO::CatHandle.new(@input_file, $*IN).lines($end_line)
+    # Alternative would be to use .lines.kv to get line num with line
 }


### PR DESCRIPTION
My arg handling in Raku needed improvement, the "where" clause should say what is wrong when rejecting input. Fixed by adding "die" statements.