### PR TITLE
ch-072/jeongoon bug fixed in both perl and raku when matching "/0+$/" has no result

### DIFF
--- a/challenge-072/jeongoon/raku/ch-1.raku
+++ b/challenge-072/jeongoon/raku/ch-1.raku
@@ -6,7 +6,7 @@ use v6.d;
 
 sub f ( Int $n where * > 0 ) { [*] 1 .. $n }
 sub zero-length-f-and-count ( Int $n where * > 0 ) {
-    ( f($n) ~~ /0+$/, '' ).chars;
+    ( f($n) ~~ /0+$/ // '' ).chars;
 }
 
 sub zero-length-reduce ( Int $n where * > 0 ) {


### PR DESCRIPTION
Sorry. I pushed wrong version one on raku