### PR TITLE
Add Rust language target directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 .vstags
 .*.swp
+
+# Rust languageoutput directory
+target/


### PR DESCRIPTION
Thought I'd add the output directory of the Rust compiler to the .gitignore