### PR TITLE
Fix wrong links in comments for all programs

### DIFF
--- a/challenge-090/wlmb/perl/ch-1.pl
+++ b/challenge-090/wlmb/perl/ch-1.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # For sequences of DNA get nucleotide counts and its complement
-# See https:/wlmb.github.io/2020/12/07/PWC90/#task-1-dna-sequence
+# See https://wlmb.github.io/2020/12/07/PWC90/#task-1-dna-sequence
 use strict;
 use warnings;
 use v5.10;

--- a/challenge-090/wlmb/perl/ch-2.pl
+++ b/challenge-090/wlmb/perl/ch-2.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Multiply two numbers using the Ethiopian Multiplication
-# See https:/wlmb.github.io/2020/12/07/PWC90/#task-2-ethiopian-multiplication
+# See https://wlmb.github.io/2020/12/07/PWC90/#task-2-ethiopian-multiplication
 use strict;
 use warnings;
 use v5.10;

--- a/challenge-091/wlmb/perl/ch-1.pl
+++ b/challenge-091/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 091
 # Task 1: Count Number
 # Simple RLE encoding of a sequence of digits.
-# See https:/wlmb.github.io/2020/12/14/PWC91/#task-1-count-number
+# See https://wlmb.github.io/2020/12/14/PWC91/#task-1-count-number
 use warnings;
 use strict;
 use v5.10;

--- a/challenge-091/wlmb/perl/ch-2.pl
+++ b/challenge-091/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 091
 # Task 2: Jump Game
 # Test if you can reach last element of an array by succesive jumps of bounded lengths.
-# See https:/wlmb.github.io/2020/12/14/PWC91/#task-2-jump-game
+# See https://wlmb.github.io/2020/12/14/PWC91/#task-2-jump-game
 
 use strict;
 use warnings;

--- a/challenge-092/wlmb/perl/ch-1.pl
+++ b/challenge-092/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 092
 # Task 1: Isomorphic strings.
 # Test if two or more strings are isomorphic
-# See https:/wlmb.github.io/2020/12/22/PWC92/#task-1-isomorphic-strings
+# See https://wlmb.github.io/2020/12/22/PWC92/#task-1-isomorphic-strings
 use warnings;
 use strict;
 use v5.10;

--- a/challenge-092/wlmb/perl/ch-2.pl
+++ b/challenge-092/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 092
 # Task 2: Insert interval.
 # Make a sorted list of non-overlapping intervals by adding or merging new intervals.
-# See https:/wlmb.github.io/2020/12/22/PWC92/#task-2-insert-interval
+# See https://wlmb.github.io/2020/12/22/PWC92/#task-2-insert-interval
 use warnings;
 use strict;
 use v5.10;

--- a/challenge-093/wlmb/perl/ch-1.pl
+++ b/challenge-093/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 093
 # Task 1: Max points.
 # Find maximum number of points on a line
-# See https:/wlmb.github.io/2020/12/28/PWC93/#task-1-max-points
+# See https://wlmb.github.io/2020/12/28/PWC93/#task-1-max-points
 use warnings;
 use strict;
 use v5.10;

--- a/challenge-093/wlmb/perl/ch-2.pl
+++ b/challenge-093/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 093
 # Task 2: Sum path.
 # Sum all possible paths from the root to the leafs.
-# See https:/wlmb.github.io/2020/12/28/PWC93/#task-2-sum-path
+# See https://wlmb.github.io/2020/12/28/PWC93/#task-2-sum-path
 use warnings;
 use strict;
 use v5.10;

--- a/challenge-094/wlmb/perl/ch-1.pl
+++ b/challenge-094/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 094
 # Task 1: Group anagrams.
 # From a list of strings recognize anagrams and group them.
-# See https:/wlmb.github.io/2021/01/04/PWC94/#task-1-group-anagrams
+# See https://wlmb.github.io/2021/01/04/PWC94/#task-1-group-anagrams
 use v5.12;
 my %anagrams;
 push @{$anagrams{join '', sort split '', $_}}, $_ foreach @ARGV;

--- a/challenge-094/wlmb/perl/ch-2.pl
+++ b/challenge-094/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 094
 # Task 2: Binary tree to linked list.
 #
-# See https:/wlmb.github.io/2021/01/04/PWC94/#task-1-binary-tree-to-linked-list
+# See https://wlmb.github.io/2021/01/04/PWC94/#task-1-binary-tree-to-linked-list
 use v5.12;
 use Text::Balanced qw(extract_bracketed extract_multiple);
 

--- a/challenge-094/wlmb/perl/ch-2a.pl
+++ b/challenge-094/wlmb/perl/ch-2a.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 094
 # Task 2: Binary tree to linked list.
 #
-# See https:/wlmb.github.io/2021/01/04/PWC94/#task-1-binary-tree-to-linked-list
+# See https://wlmb.github.io/2021/01/04/PWC94/#task-1-binary-tree-to-linked-list
 use v5.12;
 
 package Tree;

--- a/challenge-095/wlmb/perl/ch-1.pl
+++ b/challenge-095/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 095
 # Task 1: Palindrome number.
 # Figure out if a number is a palindrome.
-# See https:/wlmb.github.io/2021/01/11/PWC95/#task-1-palindrome-number
+# See https://wlmb.github.io/2021/01/11/PWC95/#task-1-palindrome-number
 use v5.12;
 use strict;
 use warnings;

--- a/challenge-095/wlmb/perl/ch-1a.pl
+++ b/challenge-095/wlmb/perl/ch-1a.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 095
 # Task 1: Palindrome number. Alternative solution
 # Figure out if a string is a palindrome after stripping punctuation.
-# See https:/wlmb.github.io/2021/01/11/PWC95/#task-1-palindrome-number
+# See https://wlmb.github.io/2021/01/11/PWC95/#task-1-palindrome-number
 use v5.12;
 use strict;
 use warnings;

--- a/challenge-095/wlmb/perl/ch-2.pl
+++ b/challenge-095/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 095
 # Task 2: Demo stack.
 # Demonstrate Stack operations.
-# See https:/wlmb.github.io/2021/01/11/PWC95/#task-2-demo-stack
+# See https://wlmb.github.io/2021/01/11/PWC95/#task-2-demo-stack
 package Stack;
 use List::Util;
 use v5.12;

--- a/challenge-096/wlmb/perl/ch-1.pl
+++ b/challenge-096/wlmb/perl/ch-1.pl
@@ -3,7 +3,7 @@
 # Task 1: Reverse words
 # Print words in reverse order separated by one space
 # Remove all non-word characters
-# See https:/wlmb.github.io/2021/01/18/PWC096/#task-1-reverse-words
+# See https://wlmb.github.io/2021/01/18/PWC096/#task-1-reverse-words
 
 use warnings;
 use strict;

--- a/challenge-096/wlmb/perl/ch-2.pl
+++ b/challenge-096/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 096
 # Task 2: Edit distance.
 # Calculate the number of editions required to edit a string and convert it into another.
-# See https:/wlmb.github.io/2021/01/11/PWC096/#task-2-edit-distance
+# See https://wlmb.github.io/2021/01/11/PWC096/#task-2-edit-distance
 
   use warnings;
   use strict;

--- a/challenge-097/wlmb/perl/ch-1.pl
+++ b/challenge-097/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 097
 # Task 1: Caesar Cipher
 #
-# See https:/wlmb.github.io/2021/01/25/PWC097/#task-1-caesar-cipher
+# See https://wlmb.github.io/2021/01/25/PWC097/#task-1-caesar-cipher
 use warnings;
 use strict;
 use v5.12;

--- a/challenge-097/wlmb/perl/ch-2.pl
+++ b/challenge-097/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 097
 # Task 1: Binary substrings
 #
-# See https:/wlmb.github.io/2021/01/25/PWC097/#task-2-binary-substrings
+# See https://wlmb.github.io/2021/01/25/PWC097/#task-2-binary-substrings
 use warnings;
 use strict;
 use v5.12;

--- a/challenge-098/wlmb/perl/ch-1.pl
+++ b/challenge-098/wlmb/perl/ch-1.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 098
 # Task 1: Read N characters
 #
-# See https:/wlmb.github.io/2021/02/01/PWC098/#task-1-read-n-characters
+# See https://wlmb.github.io/2021/02/01/PWC098/#task-1-read-n-characters
 use warnings;
 use strict;
 use v5.12;

--- a/challenge-098/wlmb/perl/ch-2.pl
+++ b/challenge-098/wlmb/perl/ch-2.pl
@@ -2,7 +2,7 @@
 # Perl weekly challenge 098
 # Task 2: Search Insert Position
 #
-# See https:/wlmb.github.io/2021/02/01/PWC098/#task-2-search-insert-position
+# See https://wlmb.github.io/2021/02/01/PWC098/#task-2-search-insert-position
 use warnings;
 use strict;
 use v5.12;


### PR DESCRIPTION
I just noticed I haven't been using double slashes in the comments that link to the corresponding blog pages. Fixed that.
Regards