### PR TITLE
Add a script to be run on CLI, repeats 99999 times 

### DIFF
--- a/challenge-118/lance-wicks/perl/ch-2.pl
+++ b/challenge-118/lance-wicks/perl/ch-2.pl
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+
+use lib './lib';
+use Knight;
+
+$|=1;
+
+my $treasures
+    = [ [ 0, 1 ], [ 1, 0 ], [ 1, 1 ], [ 2, 1 ], [ 3, 2 ], [ 5, 4 ] ];
+
+my $least = 9999;
+my $path;
+
+for ( 1 .. 99999 ) {
+    my $k   = Knight->new( treasures => $treasures );
+    my $res = $k->go;
+    if ( $res->{moves} < $least ) {
+        $least = $res->{moves};
+		$path  = $res->{path};
+		print "$least\n";
+    }
+}
+
+print "\n\nPath: ";
+for (@$path) {
+    print  "($_->[0],$_->[1]) ";
+}
+print "\nLeast moves: $least\n";

--- a/challenge-118/lance-wicks/perl/lib/Knight.pm
+++ b/challenge-118/lance-wicks/perl/lib/Knight.pm
@@ -33,8 +33,8 @@ sub go {
 
     return {
         treasures => $self->collected_treasures,
-        path      => @path,
-        moves     => 0 + @path
+        path      => \@path,
+        moves     => @path -1, # sub 1 as path includes starting position.
     };
 }
 
@@ -55,7 +55,6 @@ sub move {
 
     while (1) {
         my $direction = int rand(8);
-        #warn "**** $row, $col -> $direction";
         $new_row = 0;
         $new_col = 0;
 


### PR DESCRIPTION
A relatively short path is found with 99999 repetitions, more required to get to my best-shortest route so far of 11 moves: (7,0) (6,2) (5,4) (4,2) (2,1) (0,2) (1,0) (2,2) (0,1) (1,3) (3,2) (1,1).

I might do a parallel processing experiment as this is single threaded, and I don't like that I have lost the A-H column names, as it goes against my original intent to make this express the problem without optimisations. :)
