### PR TITLE
Challenge 122: Remove unnecessary method calls

### DIFF
--- a/challenge-122/andinus/README
+++ b/challenge-122/andinus/README
@@ -163,7 +163,7 @@ Raku
   │
   │ .put for gather for [X] ((0, 1, 2, 3) xx $score) -> @scores {
   │     take @scores if ([+] @scores) == $score;
-  │ }.map(*.grep(* !== 0).comb.grep(* !== "").join).unique.map(*.comb.map(*.Int));
+  │ }.map(*.grep(* !== 0).join).unique.map(*.comb);
   └────
 
   After we gather the lists of scores, remove 0's from there and then we

--- a/challenge-122/andinus/README.org
+++ b/challenge-122/andinus/README.org
@@ -139,7 +139,7 @@ unit sub MAIN(Int $score);
 
 .put for gather for [X] ((0, 1, 2, 3) xx $score) -> @scores {
     take @scores if ([+] @scores) == $score;
-}.map(*.grep(* !== 0).comb.grep(* !== "").join).unique.map(*.comb.map(*.Int));
+}.map(*.grep(* !== 0).join).unique.map(*.comb);
 #+end_src
 
 After we gather the lists of scores, remove 0's from there and then we

--- a/challenge-122/andinus/raku/ch-2.raku
+++ b/challenge-122/andinus/raku/ch-2.raku
@@ -3,4 +3,4 @@ unit sub MAIN(Int $score);
 
 .put for gather for [X] ((0,1, 2, 3) xx $score) -> @scores {
     take @scores if ([+] @scores) == $score;
-}.map(*.grep(* !== 0).comb.grep(* !== "").join).unique.map(*.comb.map(*.Int));
+}.map(*.grep(* !== 0).join).unique.map(*.comb);


### PR DESCRIPTION
``.comb.grep(* !== "").join'' can be replaced with ``.join''.

And we don't have to convert it back to Int since we're just printing
it.