### PR TITLE
132: Mirror Dates in Raku by James Raspass

### DIFF
--- a/challenge-132/james-raspass/README
+++ b/challenge-132/james-raspass/README
@@ -1,0 +1,1 @@
+Solution by James Raspass.

--- a/challenge-132/james-raspass/raku/ch-1.raku
+++ b/challenge-132/james-raspass/raku/ch-1.raku
@@ -1,0 +1,8 @@
+unit sub MAIN(Date() $birthday, Date() $today = Date.today);
+
+my $age = $today - $birthday;
+
+printf q:to/END/, $birthday - $age, $today + $age;
+    On the date you were born, someone who was your current age, would have been born on %s.
+    Someone born today will be your current age on %s.
+    END


### PR DESCRIPTION
```
$ raku challenge-132/james-raspass/raku/ch-1.raku 2021-09-18 2021-09-22
On the date you were born, someone who was your current age, would have been born on 2021-09-14.
Someone born today will be your current age on 2021-09-26.
```

Uses a slightly different date format but shows off coercion beautifully, the errors are very readable for other date formats:

```
$ raku challenge-132/james-raspass/raku/ch-1.raku 2021/09/18
Invalid Date string '2021/09/18'; use yyyy-mm-dd instead
```