### PR TITLE
Remove vscode settings from repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "editor.rulers": [
-        72,80,120,132
-    ],
-    "files.associations": {
-        "valarray": "c"
-    }
-}


### PR DESCRIPTION
This folder is in our .gitignore and should not be checked into this
repository. Having this in the repo will affect everyone using vs code
which might be annoying for contributors who don't like the settings.

Me for example ;) I don't like those rulers. :man_shrugging: 