### PR TITLE
Branch for challenge 183

### DIFF
--- a/challenge-183/2colours/raku/ch-1.raku
+++ b/challenge-183/2colours/raku/ch-1.raku
@@ -15,8 +15,8 @@ my \try-list = try $input.&from-json;
 when not try-list.defined {
   say 'The elements of the list should be valid according to JSON.';
 }
-when try-list.first(* !~~ Array).defined {
-  say 'The elements should all be arrays.'
+when try-list.are !~~ Array {
+  say 'The elements should all be arrays.';
 }
 my @output-arrays <==
   try-list

--- a/challenge-183/2colours/raku/ch-1.raku
+++ b/challenge-183/2colours/raku/ch-1.raku
@@ -1,0 +1,26 @@
+#!/usr/bin/env raku
+
+use v6.*;
+use immutable;
+use JSON::Fast;
+
+my $input = prompt '@list = ';
+$input .= trim;
+when not $input.&{ .starts-with('(') && .ends-with(')')} {
+  say 'Please provide a valid list of arrays.'
+}
+$input .= subst: '(', '[', :1nth;
+$input .= subst: ')', ']', :nth(*);
+my \try-list = try $input.&from-json;
+when not try-list.defined {
+  say 'The elements of the list should be valid according to JSON.';
+}
+when try-list.first(* !~~ Array).defined {
+  say 'The elements should all be arrays.'
+}
+my @output-arrays <==
+  try-list
+  .map: &immutable andthen
+  .unique
+  .map: *.&to-json(:!pretty);
+say "(@output-arrays.join(', '))";

--- a/challenge-183/2colours/raku/ch-2.raku
+++ b/challenge-183/2colours/raku/ch-2.raku
@@ -1,0 +1,29 @@
+#!/usr/bin/env raku
+
+my @dates = do for 1, 2 {
+  prompt("\$date$_ = ").Date
+};
+
+if [<=] @dates {
+  @dates .= reverse;
+}
+else {
+  print '- ';
+}
+my $delta-years = [-] @dates>>.year;
+@dates[1] .= later: years => $delta-years;
+if [<] @dates {
+  $delta-years--;
+  @dates[1] .= earlier: :1years;
+}
+my $delta-days = [-] @dates;
+my @output-parts;
+given $delta-years {
+  @output-parts.push: "$_ year" if $_ > 0;
+  @output-parts ~= 's' if $_ > 1; 
+}
+given $delta-days {
+  @output-parts.push: "$_ day" if $_ > 0;
+  @output-parts ~= 's' if $_ > 1; 
+}
+say @output-parts.join: ' ';

--- a/challenge-183/2colours/raku/ch-2.raku
+++ b/challenge-183/2colours/raku/ch-2.raku
@@ -26,4 +26,8 @@ given $delta-days {
   @output-parts.push: "$_ day" if $_ > 0;
   @output-parts ~= 's' if $_ > 1; 
 }
-say @output-parts.join: ' ';
+given @output-parts {
+  say .join: ' ' if $_;
+  say 'The dates match.' unless $_
+} 
+  


### PR DESCRIPTION
Hi,

thank you for the challenges. I personally like that they are often a bit vague because this leaves some design decisions for the solver. In this case, I spent more time deciding on the input and the output, also trying to conform with the given examples:

- ch-1: accepting JSON-compatible content, inside parentheses for the containing list. The output is also provided as JSON arrays inside a list (utilizing two Raku modules that can be installed via zef)
- ch-2: reverse dates produce negative result, 0 is not shown - TODO handle matching dates - there is no conversion between days and years so that leap-years don't cause problems, instead, the year is offset to the closest date within the interval

Please take my solution (after a little modification on my side, noticed the matching date situation). :)