### PR TITLE
Fixed error in 250-2.

### DIFF
--- a/challenge-250/robbie-hatley/perl/ch-2.pl
+++ b/challenge-250/robbie-hatley/perl/ch-2.pl
@@ -77,13 +77,13 @@ BEGIN {$t0 = time}
 # Is a given array ref a ref to a non-empty array containing only alphanumeric strings?
 sub is_array_of_alnums ($aref) {
    'ARRAY' ne ref($aref) || 0 == scalar(@$aref) and return 0;
-   for (@$aref) {!/^[[:alnum:]]+$/ and return 0}
+   for (@$aref) {!/^[a-zA-Z0-9]+$/ and return 0}
    return 1;
 }
 
 # What is the "alphanumeric string value" of a given scalar?
 sub alnum_string_value ($x) {
-   $x=~/^[[[:digit:]]+$/ and return 0+$x or return length($x);
+   $x=~/^[0-9]+$/ and return 0+$x or return length($x);
 }
 
 # What is the maximum "alphanumeric string value"

--- a/challenge-250/robbie-hatley/perl/ch-2.pl
+++ b/challenge-250/robbie-hatley/perl/ch-2.pl
@@ -87,7 +87,7 @@ sub alnum_string_value ($x) {
 }
 
 # What is the maximum "alphanumeric string value"
-#of the elements of an array of alphanumeric strings?
+# of the elements of an array of alphanumeric strings?
 sub max_alnum_string_value ($aref) {
    return max map {alnum_string_value $_} @$aref;
 }


### PR DESCRIPTION
One too many brackets: "[[[:alnum:]]". Oopsie! I changed it to "[a-zA-Z0-9]" which is much more clear.